### PR TITLE
Syntax correction in schema and seeds files

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE department (
 CREATE TABLE role (
     id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(30),
-    salary DECIMAL,
+    salary DECIMAL(9,2),
     department_id INT,
     FOREIGN KEY (department_id)
     REFERENCES department(id)
@@ -22,10 +22,7 @@ CREATE TABLE employee (
     first_name VARCHAR(30) NOT NULL,
     last_name VARCHAR(30) NOT NULL,
     role_id INT NOT NULL,
-    manager_id INT,
+    manager_id INT REFERENCES employee(id),
     FOREIGN KEY (role_id)
-    REFERENCES role(id),
-    FOREIGN KEY (manager_id)
-    REFERENCES employee(id)
-    ON DELETE SET NULL
+    REFERENCES role(id)
 )AUTO_INCREMENT = 1000;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,24 +9,23 @@ CREATE TABLE department (
 );
 
 CREATE TABLE role (
-    id INT AUTO_INCREMENT=500 PRIMARY KEY,
+    id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(30),
     salary DECIMAL,
-    department_id INT
+    department_id INT,
     FOREIGN KEY (department_id)
     REFERENCES department(id)
-    ON DELETE SET NULL
-);
+)AUTO_INCREMENT = 500;
 
 CREATE TABLE employee (
-    id INT AUTO_INCREMENT=1000 PRIMARY KEY,
+    id INT AUTO_INCREMENT PRIMARY KEY,
     first_name VARCHAR(30) NOT NULL,
     last_name VARCHAR(30) NOT NULL,
     role_id INT NOT NULL,
-    manager_id INT
+    manager_id INT,
     FOREIGN KEY (role_id)
-    REFERENCES role(id)
+    REFERENCES role(id),
     FOREIGN KEY (manager_id)
-    REFERENCES (id)
+    REFERENCES employee(id)
     ON DELETE SET NULL
-);
+)AUTO_INCREMENT = 1000;

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -5,17 +5,19 @@ VALUES
     ('Finance');
 
 INSERT INTO role (title, salary, department_id)
-    ('Junior Accountant', 60000, 0003),500
-    ('Informaticist I', 65000, 0002), 501
-    ('Technical Analyst', 75000, 0002), 502
-    ('Manager', 100000, 0003), 503
-    ('Director', 200000, 0001), 504
-    ('CEO', 500000, 0001); 505
+VALUES
+    ('Junior Accountant', 60000, 0003),
+    ('Informaticist I', 65000, 0002),
+    ('Technical Analyst', 75000, 0002),
+    ('Manager', 100000, 0003),
+    ('Director', 200000, 0001),
+    ('CEO', 500000, 0001);
 
 INSERT INTO employee (first_name, last_name, role_id, manager_id)
+VALUES
     ('Tim', 'Smith', 500, 1003),
-    ('John', 'Smith', 501, 1003)
-    ('Eric', 'Moody', 502, 1003)
-    ('Eric', 'Moody', 503, 1004)
+    ('John', 'Smith', 501, 1003),
+    ('Eric', 'Moody', 502, 1003),
+    ('Eric', 'Moody', 503, 1004),
     ('Alli', 'Burkholder', 504, 1005),
-    ('Katelyn', 'Schumacher', 505);
+    ('Katelyn', 'Schumacher', 505, 1004);


### PR DESCRIPTION
This PR corrects several syntax errors found in the schema and seeds SQL files.  The auto increment starting values were moved to the correct position.  Numbers used during creation of the role table were removed.  The role and employee table insert into statements were both lacking the VALUES keyword.  The relationship between the manager_id and id fields in the employee table was rewritten.  The schema and seeds SQL files now run without error and create the database and tables as required.